### PR TITLE
feat(connect): handle *connect.Error in HandleError

### DIFF
--- a/apperr/apperr.go
+++ b/apperr/apperr.go
@@ -310,7 +310,7 @@ func withStack() slog.Attr {
 
 	for {
 		frame, more := frames.Next()
-		sb.WriteString(fmt.Sprintf("%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line))
+		fmt.Fprintf(&sb, "%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line)
 
 		if !more {
 			break

--- a/apperr/connect/interceptor.go
+++ b/apperr/connect/interceptor.go
@@ -99,8 +99,9 @@ func NewErrorHandlingInterceptor(logger Logger) connect.UnaryInterceptorFunc {
 //
 // Error Handling:
 //   - If err is nil, returns nil
-//   - If err is not an AppErr, treats it as Unknown error and logs it
 //   - If err is an AppErr, converts it to the appropriate Connect error code
+//   - If err is a *connect.Error, preserves the original code and logs only server errors
+//   - Otherwise, treats it as Unknown error and logs it
 //
 // Security Behavior:
 //   - Server errors (5xx): Returns a generic "internal server error" message to prevent
@@ -146,18 +147,44 @@ func HandleError(ctx context.Context, err error, logger Logger, attrs ...slog.At
 	}
 
 	var appErr *apperr.AppErr
-	if !errors.As(err, &appErr) {
-		// For non-AppErr errors, treat as unknown error
-		logger.Error(ctx, "unhandled error occurred", err, attrs...)
-		return connect.NewError(connect.CodeUnknown, errInternal)
+	if errors.As(err, &appErr) {
+		if appErr.Code.IsServerError() {
+			logger.Error(ctx, "server error occurred", appErr, attrs...)
+			return connect.NewError(appErr.Code.ToConnect(), errInternal)
+		}
+
+		return connect.NewError(appErr.Code.ToConnect(), appErr)
 	}
 
-	if appErr.Code.IsServerError() {
-		logger.Error(ctx, "server error occurred", appErr, attrs...)
-		return connect.NewError(appErr.Code.ToConnect(), errInternal)
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		if isServerErrorCode(connectErr.Code()) {
+			logger.Error(ctx, "server error occurred", err, attrs...)
+		}
+
+		return connectErr
 	}
 
-	return connect.NewError(appErr.Code.ToConnect(), appErr)
+	// For non-AppErr, non-connect.Error errors, treat as unknown error
+	logger.Error(ctx, "unhandled error occurred", err, attrs...)
+	return connect.NewError(connect.CodeUnknown, errInternal)
+}
+
+// isServerErrorCode determines if a connect.Code represents a server error.
+// This mirrors codes.Code.IsServerError() but operates on connect.Code directly,
+// used when handling *connect.Error instances that bypass the AppErr layer.
+func isServerErrorCode(code connect.Code) bool {
+	switch code {
+	case connect.CodeInternal,
+		connect.CodeUnknown,
+		connect.CodeDataLoss,
+		connect.CodeUnimplemented,
+		connect.CodeUnavailable,
+		connect.CodeDeadlineExceeded:
+		return true
+	default:
+		return false
+	}
 }
 
 // errInternal is a generic error message returned to clients for server errors.

--- a/apperr/connect/interceptor_test.go
+++ b/apperr/connect/interceptor_test.go
@@ -26,7 +26,7 @@ func (l *testLogger) Error(ctx context.Context, msg string, err error, args ...s
 	for i, attr := range args {
 		attrs[i] = attr
 	}
-	l.Logger.ErrorContext(ctx, msg, append([]any{slog.Any("error", err)}, attrs...)...)
+	l.ErrorContext(ctx, msg, append([]any{slog.Any("error", err)}, attrs...)...)
 }
 
 func TestNewErrorHandlingInterceptor(t *testing.T) {

--- a/apperr/connect/interceptor_test.go
+++ b/apperr/connect/interceptor_test.go
@@ -90,6 +90,34 @@ func TestNewErrorHandlingInterceptor(t *testing.T) {
 			wantErrMsg: "unauthorized (unauthenticated)", // Connect appends error code
 		},
 		{
+			name:       "not log client connect.Error when InvalidArgument",
+			err:        connect.NewError(connect.CodeInvalidArgument, errors.New("field validation failed")),
+			wantNoLog:  true,
+			wantCode:   connect.CodeInvalidArgument,
+			wantErrMsg: "field validation failed",
+		},
+		{
+			name:       "not log client connect.Error when Unauthenticated",
+			err:        connect.NewError(connect.CodeUnauthenticated, errors.New("missing token")),
+			wantNoLog:  true,
+			wantCode:   connect.CodeUnauthenticated,
+			wantErrMsg: "missing token",
+		},
+		{
+			name:            "log server connect.Error when Internal",
+			err:             connect.NewError(connect.CodeInternal, errors.New("unexpected failure")),
+			wantLogContains: []string{"server error occurred", "rpc_method", "/TestService/TestMethod"},
+			wantCode:        connect.CodeInternal,
+			wantErrMsg:      "unexpected failure",
+		},
+		{
+			name:            "log server connect.Error when Unknown",
+			err:             connect.NewError(connect.CodeUnknown, errors.New("unknown failure")),
+			wantLogContains: []string{"server error occurred", "rpc_method", "/TestService/TestMethod"},
+			wantCode:        connect.CodeUnknown,
+			wantErrMsg:      "unknown failure",
+		},
+		{
 			name:            "log unhandled error with RPC method when non-AppErr error occurs",
 			err:             errors.New("unexpected error"),
 			wantLogContains: []string{"unhandled error occurred", "rpc_method", "/TestService/TestMethod"},

--- a/apperr/connect/interceptor_test.go
+++ b/apperr/connect/interceptor_test.go
@@ -26,7 +26,7 @@ func (l *testLogger) Error(ctx context.Context, msg string, err error, args ...s
 	for i, attr := range args {
 		attrs[i] = attr
 	}
-	l.ErrorContext(ctx, msg, append([]any{slog.Any("error", err)}, attrs...)...)
+	l.Logger.ErrorContext(ctx, msg, append([]any{slog.Any("error", err)}, attrs...)...)
 }
 
 func TestNewErrorHandlingInterceptor(t *testing.T) {


### PR DESCRIPTION
## Description

`HandleError` now recognizes `*connect.Error` as a distinct error type, preserving its original error code and applying the same server/client logging policy. This prevents upstream interceptor errors (e.g., from `connectrpc.com/validate` or `connectrpc.com/authn`) from being misclassified as "unhandled" and having their code overwritten to `Unknown`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

close: #3

## Changes Made

- Added `*connect.Error` handling branch in `HandleError` between `*apperr.AppErr` and the fallback
- Added `isServerErrorCode` helper to classify `connect.Code` values as server or client errors
- Updated doc comments on `HandleError` to document the new error type handling
- Added 4 test cases covering client and server `*connect.Error` scenarios

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
